### PR TITLE
hardcode build file path to prevent docker error

### DIFF
--- a/annotation-service/Dockerfile
+++ b/annotation-service/Dockerfile
@@ -10,7 +10,7 @@ FROM adoptopenjdk:11-jre-openj9
 
 RUN mkdir /app
 
-COPY --from=build /home/gradle/src/build/libs/*.jar /app/spring-boot-application.jar
+COPY --from=build /home/gradle/src/build/libs/annotation-service-0.0.1-SNAPSHOT.jar /app/spring-boot-application.jar
 
 ENTRYPOINT ["java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-jar", "/app/spring-boot-application.jar"]
 


### PR DESCRIPTION
this should fix the docker build errors ( #44 ).
@miczed is this hardcoding okay? Does the .jar file name never change or is a more sophisticated solution required? 