### PR TITLE
Feature/fix demo url

### DIFF
--- a/demo-frontend/.env
+++ b/demo-frontend/.env
@@ -1,1 +1,1 @@
-HIGHLIGHT_URL=http://localhost:8081/api/v1/highlight
+VITE_HIGHLIGHT_URL=http://localhost:8081/api/v1/highlight

--- a/demo-frontend/src/composables/fileClass.js
+++ b/demo-frontend/src/composables/fileClass.js
@@ -64,9 +64,9 @@ export default class File {
     };
     let outputElem = document.getElementById(this.uuid);
     //   console.log(outputElem);
-
+    
     axios
-      .post(import.meta.env.HIGHLIGHT_URL, data)
+      .post(import.meta.env.VITE_HIGHLIGHT_URL, data)
       .then((response) => {
         let newElement = document
           .createRange()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     env_file:
       - .env
     environment:
-      - HIGHLIGHT_URL=http://web-api:${WEB_API_PORT}/api/v1/highlight
+      - HIGHLIGHT_URL=http://localhost:${WEB_API_PORT}/api/v1/highlight
     ports: 
       - "${DEMO_FRONTEND_PORT}:${DEMO_FRONTEND_PORT}"
     depends_on:


### PR DESCRIPTION
web api url was not exposed in demo-frontend service because the "VITE_" prefix was missing