### PR TITLE
Feature/demo batching requests

### DIFF
--- a/demo-frontend/src/composables/axios.js
+++ b/demo-frontend/src/composables/axios.js
@@ -1,0 +1,55 @@
+import axios from "axios";
+
+const MAX_REQUESTS_COUNT = 1;
+const INTERVAL_MS = 10;
+let PENDING_REQUESTS = 0;
+
+// default axios instance
+export const axiosDefault = axios.create({});
+
+// create request limited axios instance 
+export const axiosLimited = axios.create({});
+
+// Axios Request Interceptor
+axiosLimited.interceptors.request.use(function (config) {
+  return new Promise((resolve, reject) => {
+    let interval = setInterval(() => {
+      if (PENDING_REQUESTS < MAX_REQUESTS_COUNT) {
+        PENDING_REQUESTS++;
+        console.log(`Request sent - Pending requests: ${PENDING_REQUESTS}`);
+        config.meta = config.meta || {};
+        config.meta.requestStartedAt = new Date().getTime();
+        console.log({ config });
+        clearInterval(interval);
+        resolve(config);
+      }
+    }, INTERVAL_MS);
+  });
+});
+
+// Axios Response Interceptor
+axiosLimited.interceptors.response.use(
+  function (response) {
+    PENDING_REQUESTS = Math.max(0, PENDING_REQUESTS - 1);
+    console.log(`Request resolved - Pending requests: ${PENDING_REQUESTS}`);
+    console.log({ response });
+    return Promise.resolve(response);
+  },
+  function (error) {
+    PENDING_REQUESTS = Math.max(0, PENDING_REQUESTS - 1);
+    console.log(`Request resolved - Pending requests: ${PENDING_REQUESTS}`);
+    return Promise.reject(error);
+  }
+);
+
+axiosLimited.interceptors.response.use(
+  (x) => {
+    x.responseTime = new Date().getTime() - x.config.meta.requestStartedAt;
+    return x;
+  },
+  // Handle 4xx & 5xx responses
+  (x) => {
+    x.responseTime = new Date().getTime() - x.config.meta.requestStartedAt;
+    return x;
+  }
+);

--- a/demo-frontend/src/composables/axios.js
+++ b/demo-frontend/src/composables/axios.js
@@ -1,55 +1,50 @@
 import axios from "axios";
-
-const MAX_REQUESTS_COUNT = 1;
-const INTERVAL_MS = 10;
-let PENDING_REQUESTS = 0;
+import { useSettingsStore } from "../stores/settingsStore";
 
 // default axios instance
 export const axiosDefault = axios.create({});
 
-// create request limited axios instance 
+// create request limited axios instance
 export const axiosLimited = axios.create({});
 
-// Axios Request Interceptor
-axiosLimited.interceptors.request.use(function (config) {
-  return new Promise((resolve, reject) => {
-    let interval = setInterval(() => {
-      if (PENDING_REQUESTS < MAX_REQUESTS_COUNT) {
-        PENDING_REQUESTS++;
-        console.log(`Request sent - Pending requests: ${PENDING_REQUESTS}`);
-        config.meta = config.meta || {};
-        config.meta.requestStartedAt = new Date().getTime();
-        console.log({ config });
-        clearInterval(interval);
-        resolve(config);
-      }
-    }, INTERVAL_MS);
+/*
+* This timeout wrapper is a workaround to use pinia store outside of components.
+* https://pinia.vuejs.org/core-concepts/outside-component-usage.html#single-page-applications
+*/
+setTimeout(() => {
+  const settingsStore = useSettingsStore();
+
+  // Axios Request Interceptor
+  axiosLimited.interceptors.request.use(function (config) {
+    return new Promise((resolve, reject) => {
+      let interval = setInterval(() => {
+        if (settingsStore.pendingRequests < settingsStore.maxRequests) {
+          settingsStore.pendingRequests++;
+          console.log(`Request sent - Pending requests: ${settingsStore.pendingRequests}`);
+          config.meta = config.meta || {};
+          config.meta.requestStartedAt = new Date().getTime();
+          console.log({ config });
+          clearInterval(interval);
+          resolve(config);
+        }
+      }, settingsStore.interval);
+    });
   });
-});
 
-// Axios Response Interceptor
-axiosLimited.interceptors.response.use(
-  function (response) {
-    PENDING_REQUESTS = Math.max(0, PENDING_REQUESTS - 1);
-    console.log(`Request resolved - Pending requests: ${PENDING_REQUESTS}`);
-    console.log({ response });
-    return Promise.resolve(response);
-  },
-  function (error) {
-    PENDING_REQUESTS = Math.max(0, PENDING_REQUESTS - 1);
-    console.log(`Request resolved - Pending requests: ${PENDING_REQUESTS}`);
-    return Promise.reject(error);
-  }
-);
-
-axiosLimited.interceptors.response.use(
-  (x) => {
-    x.responseTime = new Date().getTime() - x.config.meta.requestStartedAt;
-    return x;
-  },
-  // Handle 4xx & 5xx responses
-  (x) => {
-    x.responseTime = new Date().getTime() - x.config.meta.requestStartedAt;
-    return x;
-  }
-);
+  // Axios Response Interceptor
+  axiosLimited.interceptors.response.use(
+    function (response) {
+      settingsStore.pendingRequests = Math.max(0, settingsStore.pendingRequests - 1);
+      response.responseTime = new Date().getTime() - response.config.meta.requestStartedAt;
+      console.log(`Request resolved - Pending requests: ${settingsStore.pendingRequests}`);
+      console.log({ response });
+      return Promise.resolve(response);
+    },
+    function (error) {
+      settingsStore.pendingRequests = Math.max(0, settingsStore.pendingRequests - 1);
+      response.responseTime = new Date().getTime() - response.config.meta.requestStartedAt;
+      console.log(`Request resolved - Pending requests: ${settingsStore.pendingRequests}`);
+      return Promise.reject(error);
+    }
+  );
+}, 1);

--- a/demo-frontend/src/composables/fileClass.js
+++ b/demo-frontend/src/composables/fileClass.js
@@ -1,4 +1,4 @@
-import axios from "axios";
+import { axiosLimited, axiosDefault } from "./axios";
 import { v4 as uuidv4 } from 'uuid';
 export default class File {
   static jsDelivrBaseUrl = "https://cdn.jsdelivr.net/gh/";
@@ -40,7 +40,7 @@ export default class File {
   }
 
   fetchRawCode() {
-    axios
+    axiosDefault
       .get(`${File.jsDelivrBaseUrl}${this.identifier}`)
       .then((response) => {
         // console.log(response);
@@ -66,7 +66,7 @@ export default class File {
     let outputElem = document.getElementById(this.uuid);
     //   console.log(outputElem);
     
-    axios
+    axiosLimited
       .post(import.meta.env.VITE_HIGHLIGHT_URL, data)
       .then((response) => {
         let newElement = document
@@ -80,16 +80,16 @@ export default class File {
         this.status = "highlighted";
         this.dirty = false;
         this.request.endTimestamp = Date.now();
-        this.request.duration =
-          this.request.endTimestamp - this.request.startTimestamp;
+        this.request.duration = response.responseTime;
+        console.log('actual response time: ', response.responseTime)
       })
       .catch((error) => {
         console.log(error);
         outputElem.innerHTML = "Error in Highlighting Service";
         this.status = "failed";
         this.request.endTimestamp = Date.now();
-        this.request.duration =
-          this.request.endTimestamp - this.request.startTimestamp;
+        this.request.duration = response.responseTime;
+        console.log('actual response time: ', response.responseTime)
       });
   }
 

--- a/demo-frontend/src/composables/githubApiConnector.js
+++ b/demo-frontend/src/composables/githubApiConnector.js
@@ -1,10 +1,10 @@
-import axios from "axios";
+import { axiosDefault } from "./axios";
 
 const GITHUB_API_URL = "https://api.github.com";
 
 export async function getCommitsFromRepo(owner, repo) {
   try {
-    const response = await axios.get(
+    const response = await axiosDefault.get(
       `${GITHUB_API_URL}/repos/${owner}/${repo}/commits`
     );
     console.log(response);
@@ -16,7 +16,7 @@ export async function getCommitsFromRepo(owner, repo) {
 
 export async function getFilesFromTree(owner, repo, tree_sha) {
   try {
-    const response = await axios.get(
+    const response = await axiosDefault.get(
       `${GITHUB_API_URL}/repos/${owner}/${repo}/git/trees/${tree_sha}?recursive=true`
     );
     console.log(response);

--- a/demo-frontend/src/stores/settingsStore.js
+++ b/demo-frontend/src/stores/settingsStore.js
@@ -1,0 +1,14 @@
+import { defineStore } from "pinia";
+
+export const useSettingsStore = defineStore({
+  id: "settings",
+  state: () => ({
+      maxRequests: 1, // how many concurrent requests are allowed for highlighting
+      pendingRequests: 0, // amount of currently pending requests
+      interval: 10, // ms before next request is tried
+  }),
+
+  getters: {},
+
+  actions: {},
+});


### PR DESCRIPTION
- the frontend is now limited to send X concurrent requests. Currently this value is set to 1 (i.e. all requests are sent in succession), but this value will be editable in a later version.
- independent of the amount of concurrent requests, the response times will now be accurate (no accumulation due to browser-side stalling of request)